### PR TITLE
Add code generation

### DIFF
--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B8A9A6E61BFB2EFE00EC8D1A /* LLVM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */; };
 		B8A9A6E71BFB2EFE00EC8D1A /* LLVM.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */; };
 		B8A9A6EF1BFBE27C00EC8D1A /* Analysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */; };
 		B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7321BFD976E00EC8D1A /* Error.swift */; };
 		B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */; };
@@ -54,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LLVM.framework; path = ../Carthage/Build/Mac/LLVM.framework; sourceTree = "<group>"; };
+		B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenContext.swift; sourceTree = "<group>"; };
 		B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analysis.swift; sourceTree = "<group>"; };
 		B8A9A7321BFD976E00EC8D1A /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherExtensions.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				B8B97ECB1BF025C500CCFC4B /* main.swift */,
+				B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */,
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
 				B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */,
@@ -261,6 +264,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,
 				B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */,
 				B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */,

--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B8A9A7421BFDE30400EC8D1A /* PrototypeCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */; };
 		B8A9A7441BFDE31400EC8D1A /* FunctionCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */; };
 		B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */; };
+		B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7471BFDF84A00EC8D1A /* IO.swift */; };
 		B8B97EB21BF018B900CCFC4B /* KaleidoscopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97EB11BF018B900CCFC4B /* KaleidoscopeTests.swift */; };
 		B8B97EBD1BF0205400CCFC4B /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; };
 		B8B97EBE1BF0205400CCFC4B /* Either.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -75,6 +76,7 @@
 		B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrototypeCodegen.swift; sourceTree = "<group>"; };
 		B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionCodegen.swift; sourceTree = "<group>"; };
 		B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenUtils.swift; sourceTree = "<group>"; };
+		B8A9A7471BFDF84A00EC8D1A /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
 		B8B97E9E1BF018B900CCFC4B /* kaleidoscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kaleidoscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97EA81BF018B900CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8B97EAD1BF018B900CCFC4B /* KaleidoscopeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KaleidoscopeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -158,6 +160,7 @@
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
 				B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */,
+				B8A9A7471BFDF84A00EC8D1A /* IO.swift */,
 				B8B97ECA1BF0207C00CCFC4B /* Supporting Files */,
 			);
 			path = Kaleidoscope;
@@ -301,6 +304,7 @@
 				B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,
 				B8A9A7421BFDE30400EC8D1A /* PrototypeCodegen.swift in Sources */,
+				B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */,
 				B8A9A7401BFDE2F600EC8D1A /* CallCodegen.swift in Sources */,
 				B8A9A73E1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift in Sources */,
 				B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */,

--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 		B8A9A6EF1BFBE27C00EC8D1A /* Analysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */; };
 		B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7321BFD976E00EC8D1A /* Error.swift */; };
 		B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */; };
+		B8A9A73A1BFDE2D500EC8D1A /* NumberCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7391BFDE2D500EC8D1A /* NumberCodegen.swift */; };
+		B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A73B1BFDE2E100EC8D1A /* VariableCodegen.swift */; };
+		B8A9A73E1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A73D1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift */; };
+		B8A9A7401BFDE2F600EC8D1A /* CallCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A73F1BFDE2F600EC8D1A /* CallCodegen.swift */; };
+		B8A9A7421BFDE30400EC8D1A /* PrototypeCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */; };
+		B8A9A7441BFDE31400EC8D1A /* FunctionCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */; };
+		B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */; };
 		B8B97EB21BF018B900CCFC4B /* KaleidoscopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97EB11BF018B900CCFC4B /* KaleidoscopeTests.swift */; };
 		B8B97EBD1BF0205400CCFC4B /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; };
 		B8B97EBE1BF0205400CCFC4B /* Either.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -61,6 +68,13 @@
 		B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analysis.swift; sourceTree = "<group>"; };
 		B8A9A7321BFD976E00EC8D1A /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherExtensions.swift; sourceTree = "<group>"; };
+		B8A9A7391BFDE2D500EC8D1A /* NumberCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberCodegen.swift; sourceTree = "<group>"; };
+		B8A9A73B1BFDE2E100EC8D1A /* VariableCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableCodegen.swift; sourceTree = "<group>"; };
+		B8A9A73D1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryOperatorCodegen.swift; sourceTree = "<group>"; };
+		B8A9A73F1BFDE2F600EC8D1A /* CallCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallCodegen.swift; sourceTree = "<group>"; };
+		B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrototypeCodegen.swift; sourceTree = "<group>"; };
+		B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionCodegen.swift; sourceTree = "<group>"; };
+		B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenUtils.swift; sourceTree = "<group>"; };
 		B8B97E9E1BF018B900CCFC4B /* kaleidoscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kaleidoscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97EA81BF018B900CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8B97EAD1BF018B900CCFC4B /* KaleidoscopeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KaleidoscopeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,6 +115,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B8A9A7381BFDE2BA00EC8D1A /* Codegen */ = {
+			isa = PBXGroup;
+			children = (
+				B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */,
+				B8A9A7391BFDE2D500EC8D1A /* NumberCodegen.swift */,
+				B8A9A73B1BFDE2E100EC8D1A /* VariableCodegen.swift */,
+				B8A9A73D1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift */,
+				B8A9A73F1BFDE2F600EC8D1A /* CallCodegen.swift */,
+				B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */,
+				B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */,
+			);
+			path = Codegen;
+			sourceTree = "<group>";
+		};
 		B8B97E951BF018B900CCFC4B = {
 			isa = PBXGroup;
 			children = (
@@ -126,6 +154,7 @@
 				B8B97ECB1BF025C500CCFC4B /* main.swift */,
 				B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */,
 				B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */,
+				B8A9A7381BFDE2BA00EC8D1A /* Codegen */,
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
 				B8A9A7361BFDA18800EC8D1A /* EitherExtensions.swift */,
@@ -268,8 +297,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
+				B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */,
+				B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,
+				B8A9A7421BFDE30400EC8D1A /* PrototypeCodegen.swift in Sources */,
+				B8A9A7401BFDE2F600EC8D1A /* CallCodegen.swift in Sources */,
+				B8A9A73E1BFDE2ED00EC8D1A /* BinaryOperatorCodegen.swift in Sources */,
 				B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */,
+				B8A9A7441BFDE31400EC8D1A /* FunctionCodegen.swift in Sources */,
+				B8A9A73A1BFDE2D500EC8D1A /* NumberCodegen.swift in Sources */,
 				B8A9A6E91BFB354A00EC8D1A /* Codegenable.swift in Sources */,
 				B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */,
 				B8A9A6EF1BFBE27C00EC8D1A /* Analysis.swift in Sources */,

--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B8A9A6E61BFB2EFE00EC8D1A /* LLVM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */; };
 		B8A9A6E71BFB2EFE00EC8D1A /* LLVM.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B8A9A6E91BFB354A00EC8D1A /* Codegenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */; };
 		B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */; };
 		B8A9A6EF1BFBE27C00EC8D1A /* Analysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */; };
 		B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7321BFD976E00EC8D1A /* Error.swift */; };
@@ -55,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		B8A9A6E51BFB2EFE00EC8D1A /* LLVM.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LLVM.framework; path = ../Carthage/Build/Mac/LLVM.framework; sourceTree = "<group>"; };
+		B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Codegenable.swift; sourceTree = "<group>"; };
 		B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenContext.swift; sourceTree = "<group>"; };
 		B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analysis.swift; sourceTree = "<group>"; };
 		B8A9A7321BFD976E00EC8D1A /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				B8B97ECB1BF025C500CCFC4B /* main.swift */,
+				B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */,
 				B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */,
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
@@ -267,6 +270,7 @@
 				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,
 				B8A9A7371BFDA18800EC8D1A /* EitherExtensions.swift in Sources */,
+				B8A9A6E91BFB354A00EC8D1A /* Codegenable.swift in Sources */,
 				B8A9A7331BFD976E00EC8D1A /* Error.swift in Sources */,
 				B8A9A6EF1BFBE27C00EC8D1A /* Analysis.swift in Sources */,
 			);

--- a/Kaleidoscope/Codegen/BinaryOperatorCodegen.swift
+++ b/Kaleidoscope/Codegen/BinaryOperatorCodegen.swift
@@ -1,0 +1,40 @@
+//
+//  BinaryOperatorCodegen.swift
+//  Kaleidoscope
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+extension BinaryOperatorExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        let left = attemptCast(self.left) >>- codegenInContext(context)
+        let right = attemptCast(self.right) >>- codegenInContext(context)
+        
+        return left &&& right >>- context.generateBinaryOperation(code)
+    }
+}
+
+private extension CodegenContext {
+    func generateBinaryOperation(code: Character)(left: ValueType, right: ValueType) -> Either<Error, ValueType> {
+        switch code {
+        case "+":
+            return .right(builder.buildFAdd(left: left, right: right, name: "addtmp"))
+        case "-":
+            return .right(builder.buildFSub(left: left, right: right, name: "subtmp"))
+        case "*":
+            return .right(builder.buildFMul(left: left, right: right, name: "multmp"))
+        case "<":
+            let result = builder.buildFCmp(LLVMRealULT, left: left, right: right, name: "cmptmp")
+            let double = RealType.double(inContext: context)
+            return .right(builder.buildUIToFP(result, destinationType: double, name: "booltmp"))
+        case let unknown:
+            return .left(.codegenError("Unknown binary operator `\(unknown)`"))
+        }
+    }
+}

--- a/Kaleidoscope/Codegen/CallCodegen.swift
+++ b/Kaleidoscope/Codegen/CallCodegen.swift
@@ -1,0 +1,44 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+extension CallExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return generateCall(context).map(id)
+    }
+    
+    func generateCall(context: CodegenContext) -> Either<Error, CallInstruction> {
+        return context.getPrototypeNamed(callee, argCount: UInt32(args.count))
+            &&& context.generateValues(args)
+            >>- context.generateCall
+    }
+}
+
+private extension CodegenContext {
+    func getPrototypeNamed(name: String, argCount: UInt32) -> Either<Error, Function> {
+        return prototypeNamed(name)
+            .flatMap { function in
+                guard function.paramCount == argCount else {
+                    return .left(.codegenError("Incorrect number of arguments passed to `\(name)`"))
+                }
+                return .right(function)
+            }
+    }
+    
+    func generateValues(expressions: [ValueExpression]) -> Either<Error, [ValueType]> {
+        return expressions
+            .map(attemptCast)
+            .compact()
+            .flatMapEach(codegenInContext(self))
+    }
+    
+    func generateCall(callee: Function, args: [ValueType]) -> Either<Error, CallInstruction> {
+        return .right(builder.buildCall(callee, args: args, name: "calltmp"))
+    }
+}

--- a/Kaleidoscope/Codegen/CodegenUtils.swift
+++ b/Kaleidoscope/Codegen/CodegenUtils.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import Either
+import LLVM
+
+internal func codegenInContext(context: CodegenContext)(codegenable: Codegenable) -> Either<Error, ValueType> {
+    return codegenable.codegen(context)
+}
+
+internal func attemptCast<T,U>(value: T) -> Either<Error, U> {
+    guard let casted = value as? U else {
+        return .left(.codegenError("Unable to cast value of type `\(T.self)` to `\(U.self)`"))
+    }
+    return .right(casted)
+}

--- a/Kaleidoscope/Codegen/CodegenUtils.swift
+++ b/Kaleidoscope/Codegen/CodegenUtils.swift
@@ -12,7 +12,7 @@ internal func codegenInContext(context: CodegenContext)(codegenable: Codegenable
 
 internal func attemptCast<T,U>(value: T) -> Either<Error, U> {
     guard let casted = value as? U else {
-        return .left(.codegenError("Unable to cast value of type `\(T.self)` to `\(U.self)`"))
+        return .left(Error(kind: .UnknownError, message: "Unable to cast value of type `\(T.self)` to `\(U.self)`"))
     }
     return .right(casted)
 }

--- a/Kaleidoscope/Codegen/FunctionCodegen.swift
+++ b/Kaleidoscope/Codegen/FunctionCodegen.swift
@@ -8,7 +8,6 @@ import KaleidoscopeLang
 import Either
 import Prelude
 
-
 extension FunctionExpression : Codegenable {
     func codegen(context: CodegenContext) -> Either<Error, ValueType> {
         return generateFunction(context).map(id)

--- a/Kaleidoscope/Codegen/FunctionCodegen.swift
+++ b/Kaleidoscope/Codegen/FunctionCodegen.swift
@@ -1,0 +1,61 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+
+extension FunctionExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return generateFunction(context).map(id)
+    }
+    
+    func generateFunction(context: CodegenContext) -> Either<Error, Function> {
+        // Clear scope
+        context.clearScope()
+        
+        return prototype
+            .generateFunction(context)
+            .flatMap(context.addArguments(prototype.args))
+            .flatMap(context.buildBodyOfFunction(body))
+    }
+}
+
+private extension CodegenContext {
+    func addArguments(args: [String])(toFunction function: Function) -> Either<Error, Function> {
+        return args
+            .enumerate()
+            .map({ ($1, function.paramAtIndex(UInt32($0))) })
+            .map(addValueToScope)
+            .compact()
+            .map(const(function))
+    }
+    
+    private func buildBodyOfFunction(body: ValueExpression)(function: Function) -> Either<Error, Function> {
+        // Create a new basic block to start insertion into.
+        let block = function.appendBasicBlock("entry", context: context)
+        
+        // Position the builder at the end of the block
+        builder.positionAtEnd(block: block)
+        
+        // Generate the body
+        guard let codegenableBody = body as? Codegenable else {
+            return .left(.codegenError("Body \(body) is not codegenable"))
+        }
+        let returnValue = codegenableBody.codegen(self).map({ builder.buildReturn(value: $0) })
+        
+        // Verify the function along the way
+        return returnValue &&& verifyFunction(function) >>- const(.right(function))
+    }
+    
+    private func verifyFunction(function: Function) -> Either<Error, ValueType> {
+        guard function.verify() else {
+            return .left(.codegenError("Unable to verify `\(function.name ?? "(null)")`"))
+        }
+        return .right(function)
+    }
+}

--- a/Kaleidoscope/Codegen/NumberCodegen.swift
+++ b/Kaleidoscope/Codegen/NumberCodegen.swift
@@ -9,8 +9,6 @@ import Either
 import Prelude
 
 extension NumberExpression : Codegenable {
-    typealias Result = RealConstant
-    
     func codegen(context: CodegenContext) -> Either<Error, ValueType> {
         return context.generateConstant(value).map(id)
     }

--- a/Kaleidoscope/Codegen/NumberCodegen.swift
+++ b/Kaleidoscope/Codegen/NumberCodegen.swift
@@ -1,0 +1,24 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+extension NumberExpression : Codegenable {
+    typealias Result = RealConstant
+    
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return context.generateConstant(value).map(id)
+    }
+}
+
+private extension CodegenContext {
+    func generateConstant(value: Double) -> Either<Error, RealConstant> {
+        let doubleType = RealType.double(inContext: context)
+        return .right(RealConstant.type(doubleType, value: value))
+    }
+}

--- a/Kaleidoscope/Codegen/PrototypeCodegen.swift
+++ b/Kaleidoscope/Codegen/PrototypeCodegen.swift
@@ -1,0 +1,67 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+extension PrototypeExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return generateFunction(context).map(id)
+    }
+    
+    func generateFunction(context: CodegenContext) -> Either<Error, Function> {
+        return context.getOrBuildPrototype(name, args: args) >>- context.nameArgsForFunction(args)
+    }
+}
+
+
+private extension CodegenContext {
+    private func nameArgsForFunction(args: [String])(function: Function) -> Either<Error, Function> {
+        for (i, argName) in args.enumerate() {
+            var arg = function.paramAtIndex(UInt32(i))
+            arg.name = argName
+        }
+        return .right(function)
+    }
+
+    private func getExistingPrototype(name: String, args: [String]) -> Either<Error, Function?> {
+        guard let function = module.functionByName(name) else {
+            return .right(nil)
+        }
+        // TODO:
+//        if !function.isDeclaration {
+//            throw "Redefinition of function."
+//        }
+        if function.paramCount != UInt32(args.count) {
+            return .left(.codegenError("Redeclaration of `\(name)` with different number of args."))
+        }
+        return .right(function)
+    }
+
+    private func buildPrototype(name: String, args: [String]) -> Either<Error, Function> {
+        let doubleType = RealType.double(inContext: context)
+        let paramTypes: [TypeType] = Array(count: args.count, repeatedValue: doubleType)
+        let type = FunctionType(returnType: doubleType, paramTypes: paramTypes, isVarArg: false)
+        let function = Function(name: name, type: type, inModule: module)
+        if function.name != name {
+            return .left(.codegenError("Error generating prototype `\(name)`: actually generated `\(function.name ?? "(null)")`"))
+        }
+        return .right(function)
+    }
+
+    /// Attempt to retrieve the current pro
+    private func getOrBuildPrototype(name: String, args: [String]) -> Either<Error, Function> {
+        return getExistingPrototype(name, args: args)
+            .flatMap { existing in
+                if let existing = existing {
+                    return .right(existing)
+                } else {
+                    return buildPrototype(name, args: args)
+                }
+        }
+    }
+}

--- a/Kaleidoscope/Codegen/VariableCodegen.swift
+++ b/Kaleidoscope/Codegen/VariableCodegen.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+import Prelude
+
+extension VariableExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return context.valueInScope(name)
+    }
+}

--- a/Kaleidoscope/CodegenContext.swift
+++ b/Kaleidoscope/CodegenContext.swift
@@ -1,0 +1,51 @@
+//
+//  Created by Ben Cochran on 11/17/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import KaleidoscopeLang
+import Either
+
+class CodegenContext {
+    let module: Module
+    let builder: Builder
+    let context: Context
+    
+    private var scope: [String:ValueType] = [:]
+    private var prototypes: [String:PrototypeExpression] = [:]
+    
+    init(moduleName: String, context: Context) {
+        self.context = context
+        module = Module(name: moduleName, context: context)
+        builder = Builder(inContext: context)
+    }
+    
+    func prototypeNamed(name: String) -> Either<Error, Function> {
+        guard let proto = module.functionByName(name) else {
+            return .left(.codegenError("No prototype named \(name)"))
+        }
+        return .right(proto)
+    }
+    
+    // MARK: Scope
+    
+    func clearScope() {
+        self.scope = [:]
+    }
+    
+    func valueInScope(name: String) -> Either<Error, ValueType> {
+        guard let value = scope[name] else {
+            return .left(.codegenError("No value in scope named `\(name)`"))
+        }
+        return .right(value)
+    }
+    
+    func addValueToScope(name: String, value: ValueType) -> Either<Error, ValueType> {
+        guard !scope.keys.contains(name) else {
+            return .left(.codegenError("Value already declared in scope: `\(name)`"))
+        }
+        scope[name] = value
+        return .right(value)
+    }
+}

--- a/Kaleidoscope/Codegenable.swift
+++ b/Kaleidoscope/Codegenable.swift
@@ -1,0 +1,14 @@
+//
+//  Created by Ben Cochran on 11/17/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import Either
+
+/// Defined a type that can generate LLVM commands into the given context
+protocol Codegenable {
+    /// Generate the value’s LLVM IR representation into the given context and return the result
+    /// (or an error if there is one)
+    func codegen(context: CodegenContext) -> Either<Error, ValueType>
+}

--- a/Kaleidoscope/EitherExtensions.swift
+++ b/Kaleidoscope/EitherExtensions.swift
@@ -49,3 +49,17 @@ extension SequenceType where Generator.Element : EitherType {
         }
     }
 }
+
+extension EitherType where RightType : SequenceType {
+    /// Returns the `compact`ed result of applying `transform` to each of the `Right` values or re-wraps `Left`
+    func flatMapEach<V>(@noescape transform: RightType.Generator.Element -> Either<LeftType, V>) -> Either<LeftType, [V]> {
+        return either(
+            ifLeft: Either<LeftType, [V]>.left,
+            ifRight: { $0.flatMap(transform).compact() })
+    }
+
+    /// Maps each `Right` value with `transform`, or re-wraps `Left`.
+    func mapEach<V>(@noescape transform: RightType.Generator.Element -> V) -> Either<LeftType, [V]> {
+        return flatMapEach { .right(transform($0)) }
+    }
+}

--- a/Kaleidoscope/Error.swift
+++ b/Kaleidoscope/Error.swift
@@ -8,6 +8,7 @@ import KaleidoscopeLang
 public enum ErrorKind {
     case ParseError(KaleidoscopeLang.Error)
     case AnalysisError
+    case CodegenError
     case UnknownError
 }
 
@@ -37,5 +38,8 @@ extension Error {
     }
     public static func analysisError(message: String) -> Error {
         return Error(kind: .AnalysisError, message: message)
+    }
+    public static func codegenError(message: String) -> Error {
+        return Error(kind: .CodegenError, message: message)
     }
 }

--- a/Kaleidoscope/IO.swift
+++ b/Kaleidoscope/IO.swift
@@ -1,0 +1,27 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import Foundation
+
+enum OutputStream {
+    case Out
+    case Err
+    case Null
+}
+
+extension OutputStream : OutputStreamType {
+    func write(string: String) {
+        let handle: NSFileHandle
+        switch self {
+        case .Out:
+            handle = .fileHandleWithStandardOutput()
+        case .Err:
+            handle = .fileHandleWithStandardError()
+        case .Null:
+            handle = .fileHandleWithNullDevice()
+        }
+        handle.writeData(string.dataUsingEncoding(NSUTF8StringEncoding)!)
+    }
+}

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2015 Ben Cochran. All rights reserved.
 //
 
-import Foundation
 import KaleidoscopeLang
 import LLVM
 import Either

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 import KaleidoscopeLang
+import LLVM
 import Either
 
+let context = CodegenContext(moduleName: "kaleidoscope", context: Context.globalContext)
 
 let lines = [
     "extern addThree(a b c);",
@@ -26,11 +28,19 @@ let result = lines
     .compact()
     // Analize the expressions
     .flatMap(Analyzer.analyze)
+    // Attempt to cast each Expression to Codegenable
+    .flatMapEach(attemptCast)
+    // Perform code generation in the context
+    .flatMapEach(codegenInContext(context))
 
 if case let .Left(error) = result {
     print("Failed: \(error)")
     exit(1)
-} else {
-    print("Success!")
-    exit(0)
 }
+
+guard let ir = context.module.string else {
+    print("Failed to generate IR")
+    exit(1)
+}
+
+print(ir)

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -10,6 +10,9 @@ import KaleidoscopeLang
 import LLVM
 import Either
 
+var stdout = OutputStream.Out
+var stderr = OutputStream.Err
+
 let context = CodegenContext(moduleName: "kaleidoscope", context: Context.globalContext)
 
 let lines = [
@@ -33,13 +36,13 @@ let result = lines
     .flatMapEach(codegenInContext(context))
 
 if case let .Left(error) = result {
-    print("Failed: \(error)")
+    print("Failed: \(error)", toStream: &stderr)
     exit(1)
 }
 
 guard let ir = context.module.string else {
-    print("Failed to generate IR")
+    print("Failed to generate IR", toStream: &stderr)
     exit(1)
 }
 
-print(ir)
+print(ir, toStream: &stdout)


### PR DESCRIPTION
Adds code to generate all expression types and modifies `main.swift` to generate our sample.

The following code:

```
extern addThree(a b c);

def add(a b)
    a + b;

def addThree(x y z)
    add(add(x y) z);
```

Generates the following:

``` llvm
; ModuleID = 'kaleidoscope'

define double @addThree(double, double, double) {
entry:
  %calltmp = call double @add(double %0, double %1)
  %calltmp1 = call double @add(double %calltmp, double %2)
  ret double %calltmp1
}

define double @add(double, double) {
entry:
  %addtmp = fadd double %0, %1
  ret double %addtmp
}
```
