### PR TITLE
Handle `main`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "bencochran/KaleidoscopeLang" "c5fdc20481019fbf489542edb7d2c7c1efa4b381"
 github "bencochran/LLVM.swift" "e31992709b6a8c850b15a953580702d22f6f9fc5"
+github "robrix/Either" ~> 1.3.1

--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B8A9A7441BFDE31400EC8D1A /* FunctionCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */; };
 		B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */; };
 		B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7471BFDF84A00EC8D1A /* IO.swift */; };
+		B8A9A74A1BFEE63200EC8D1A /* MainCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7491BFEE63200EC8D1A /* MainCodegen.swift */; };
 		B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */; };
 		B8B97EB21BF018B900CCFC4B /* KaleidoscopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97EB11BF018B900CCFC4B /* KaleidoscopeTests.swift */; };
 		B8B97EBD1BF0205400CCFC4B /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; };
@@ -78,6 +79,7 @@
 		B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionCodegen.swift; sourceTree = "<group>"; };
 		B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenUtils.swift; sourceTree = "<group>"; };
 		B8A9A7471BFDF84A00EC8D1A /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
+		B8A9A7491BFEE63200EC8D1A /* MainCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainCodegen.swift; sourceTree = "<group>"; };
 		B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainExpression.swift; sourceTree = "<group>"; };
 		B8B97E9E1BF018B900CCFC4B /* kaleidoscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kaleidoscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97EA81BF018B900CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				B8A9A73F1BFDE2F600EC8D1A /* CallCodegen.swift */,
 				B8A9A7411BFDE30400EC8D1A /* PrototypeCodegen.swift */,
 				B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */,
+				B8A9A7491BFEE63200EC8D1A /* MainCodegen.swift */,
 			);
 			path = Codegen;
 			sourceTree = "<group>";
@@ -303,6 +306,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
+				B8A9A74A1BFEE63200EC8D1A /* MainCodegen.swift in Sources */,
 				B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */,
 				B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */,
 				B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */,

--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B8A9A7441BFDE31400EC8D1A /* FunctionCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */; };
 		B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */; };
 		B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7471BFDF84A00EC8D1A /* IO.swift */; };
+		B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */; };
 		B8B97EB21BF018B900CCFC4B /* KaleidoscopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97EB11BF018B900CCFC4B /* KaleidoscopeTests.swift */; };
 		B8B97EBD1BF0205400CCFC4B /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; };
 		B8B97EBE1BF0205400CCFC4B /* Either.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -77,6 +78,7 @@
 		B8A9A7431BFDE31400EC8D1A /* FunctionCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionCodegen.swift; sourceTree = "<group>"; };
 		B8A9A7451BFDE36300EC8D1A /* CodegenUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodegenUtils.swift; sourceTree = "<group>"; };
 		B8A9A7471BFDF84A00EC8D1A /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
+		B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainExpression.swift; sourceTree = "<group>"; };
 		B8B97E9E1BF018B900CCFC4B /* kaleidoscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kaleidoscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97EA81BF018B900CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8B97EAD1BF018B900CCFC4B /* KaleidoscopeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KaleidoscopeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -156,6 +158,7 @@
 				B8B97ECB1BF025C500CCFC4B /* main.swift */,
 				B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */,
 				B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */,
+				B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */,
 				B8A9A7381BFDE2BA00EC8D1A /* Codegen */,
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
@@ -302,6 +305,7 @@
 				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
 				B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */,
 				B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */,
+				B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,
 				B8A9A7421BFDE30400EC8D1A /* PrototypeCodegen.swift in Sources */,
 				B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */,

--- a/Kaleidoscope/Codegen/CodegenUtils.swift
+++ b/Kaleidoscope/Codegen/CodegenUtils.swift
@@ -12,7 +12,7 @@ internal func codegenInContext(context: CodegenContext)(codegenable: Codegenable
 
 internal func attemptCast<T,U>(value: T) -> Either<Error, U> {
     guard let casted = value as? U else {
-        return .left(Error(kind: .UnknownError, message: "Unable to cast value of type `\(T.self)` to `\(U.self)`"))
+        return .left(Error(kind: .UnknownError, message: "Unable to cast value of type `\(Mirror(reflecting: value).subjectType)` to `\(U.self)`"))
     }
     return .right(casted)
 }

--- a/Kaleidoscope/Codegen/FunctionCodegen.swift
+++ b/Kaleidoscope/Codegen/FunctionCodegen.swift
@@ -24,8 +24,8 @@ extension FunctionExpression : Codegenable {
     }
 }
 
-private extension CodegenContext {
-    func addArguments(args: [String])(toFunction function: Function) -> Either<Error, Function> {
+internal extension CodegenContext {
+    private func addArguments(args: [String])(toFunction function: Function) -> Either<Error, Function> {
         return args
             .enumerate()
             .map({ ($1, function.paramAtIndex(UInt32($0))) })
@@ -51,7 +51,7 @@ private extension CodegenContext {
         return returnValue &&& verifyFunction(function) >>- const(.right(function))
     }
     
-    private func verifyFunction(function: Function) -> Either<Error, ValueType> {
+    internal func verifyFunction(function: Function) -> Either<Error, ValueType> {
         guard function.verify() else {
             return .left(.codegenError("Unable to verify `\(function.name ?? "(null)")`"))
         }

--- a/Kaleidoscope/Codegen/MainCodegen.swift
+++ b/Kaleidoscope/Codegen/MainCodegen.swift
@@ -1,0 +1,63 @@
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import KaleidoscopeLang
+import Either
+import LLVM
+import Prelude
+
+extension MainExpression : Codegenable {
+    func codegen(context: CodegenContext) -> Either<Error, ValueType> {
+        return generateMain(context).map(id)
+    }
+    
+    func generatePrototype(context: CodegenContext) -> Either<Error, Function> {
+        return context.buildMainPrototype()
+    }
+    
+    func generateMain(context: CodegenContext) -> Either<Error, Function> {
+        // Clear scope
+        context.clearScope()
+        
+        return generatePrototype(context)
+            .flatMap(context.buildMainBody(body))
+    }
+}
+
+extension CodegenContext {
+    private func buildMainPrototype() -> Either<Error, Function> {
+        let intType = IntType.int32(inContext: context)
+        let type = FunctionType(returnType: intType, paramTypes: [], isVarArg: false)
+        let function = Function(name: "main", type: type, inModule: module)
+        if function.name != "main" {
+            return .left(.codegenError("Error generating prototype `main`: actually generated `\(function.name ?? "(null)")`"))
+        }
+        return .right(function)
+    }
+    
+    private func buildMainBody(body: ValueExpression)(function: Function) -> Either<Error, Function> {
+        // Create a new basic block to start insertion into.
+        let block = function.appendBasicBlock("entry", context: context)
+        
+        // Position the builder at the end of the block
+        builder.positionAtEnd(block: block)
+        
+        guard let codegenableBody = body as? Codegenable else {
+            return .left(.codegenError("Body \(body) is not codegenable"))
+        }
+        
+        let intType = IntType.int32(inContext: context)
+        let returnValue = codegenableBody
+            // Generate the body
+            .codegen(self)
+            // Cast its result to an int
+            .map({ builder.buildFPToUI($0, destinationType: intType, name: "casttmp") })
+            // Build the return
+            .map({ builder.buildReturn(value: $0) })
+        
+        // Verify the function along the way
+        return returnValue &&& verifyFunction(function) >>- const(.right(function))
+    }
+}

--- a/Kaleidoscope/MainExpression.swift
+++ b/Kaleidoscope/MainExpression.swift
@@ -1,0 +1,33 @@
+//
+//  MainExpression.swift
+//  Kaleidoscope
+//
+//  Created by Ben Cochran on 11/19/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import KaleidoscopeLang
+import Either
+
+struct MainExpression : TopLevelExpression, Equatable {
+    let body: ValueExpression
+    init(body: ValueExpression) {
+        self.body = body
+    }
+}
+
+func == (left: MainExpression, right: MainExpression) -> Bool {
+    return left.body == right.body
+}
+
+func liftMain(expression: Expression) -> Either<Error, Expression> {
+    guard let functionExpression = expression as? FunctionExpression
+        where functionExpression.prototype.name == "main" else {
+            // Pass non-functions and functions not named "main" through
+            return .right(expression)
+    }
+    guard functionExpression.prototype.args.count == 0 else {
+        return .left(Error(kind: ErrorKind.UnknownError, message: "`main` cannot take arguments"))
+    }
+    return .right(MainExpression(body: functionExpression.body))
+}


### PR DESCRIPTION
This generates `main` functions differently, so that they convert their result to an integer. Meaning you can now execute Kaleidoscope code :grinning: (though the only available output right now is via the exit status, but… baby steps).

Given:

```
extern addThree(a b c);

def main()
    addThree(1 2 3)

def add(a b)
    a + b;

def addThree(x y z)
    add(add(x y) z);
```

We can build and run like:

```
$ ./kaleidoscope | lli; echo $? 
> 6
```

Closes #4 
