### PR TITLE
Add `putchard` and `printd` as standard functions

### DIFF
--- a/Kaleidoscope.xcodeproj/project.pbxproj
+++ b/Kaleidoscope.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B8A9A7481BFDF84A00EC8D1A /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7471BFDF84A00EC8D1A /* IO.swift */; };
 		B8A9A74A1BFEE63200EC8D1A /* MainCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A7491BFEE63200EC8D1A /* MainCodegen.swift */; };
 		B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */; };
+		B8A9A78F1BFFC0C300EC8D1A /* LibraryCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A9A78E1BFFC0C300EC8D1A /* LibraryCodegen.swift */; };
 		B8B97EB21BF018B900CCFC4B /* KaleidoscopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B97EB11BF018B900CCFC4B /* KaleidoscopeTests.swift */; };
 		B8B97EBD1BF0205400CCFC4B /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; };
 		B8B97EBE1BF0205400CCFC4B /* Either.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B8B97EBC1BF0205400CCFC4B /* Either.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -81,6 +82,7 @@
 		B8A9A7471BFDF84A00EC8D1A /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
 		B8A9A7491BFEE63200EC8D1A /* MainCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainCodegen.swift; sourceTree = "<group>"; };
 		B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainExpression.swift; sourceTree = "<group>"; };
+		B8A9A78E1BFFC0C300EC8D1A /* LibraryCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryCodegen.swift; sourceTree = "<group>"; };
 		B8B97E9E1BF018B900CCFC4B /* kaleidoscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kaleidoscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8B97EA81BF018B900CCFC4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B8B97EAD1BF018B900CCFC4B /* KaleidoscopeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KaleidoscopeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +164,7 @@
 				B8A9A6E81BFB354A00EC8D1A /* Codegenable.swift */,
 				B8A9A6EA1BFB363800EC8D1A /* CodegenContext.swift */,
 				B8A9A74B1BFEE79A00EC8D1A /* MainExpression.swift */,
+				B8A9A78E1BFFC0C300EC8D1A /* LibraryCodegen.swift */,
 				B8A9A7381BFDE2BA00EC8D1A /* Codegen */,
 				B8A9A6EE1BFBE27C00EC8D1A /* Analysis.swift */,
 				B8A9A7321BFD976E00EC8D1A /* Error.swift */,
@@ -308,6 +311,7 @@
 				B8A9A6EB1BFB363800EC8D1A /* CodegenContext.swift in Sources */,
 				B8A9A74A1BFEE63200EC8D1A /* MainCodegen.swift in Sources */,
 				B8A9A7461BFDE36300EC8D1A /* CodegenUtils.swift in Sources */,
+				B8A9A78F1BFFC0C300EC8D1A /* LibraryCodegen.swift in Sources */,
 				B8A9A73C1BFDE2E100EC8D1A /* VariableCodegen.swift in Sources */,
 				B8A9A74C1BFEE79A00EC8D1A /* MainExpression.swift in Sources */,
 				B8B97ECC1BF025C500CCFC4B /* main.swift in Sources */,

--- a/Kaleidoscope/EitherExtensions.swift
+++ b/Kaleidoscope/EitherExtensions.swift
@@ -53,9 +53,7 @@ extension SequenceType where Generator.Element : EitherType {
 extension EitherType where RightType : SequenceType {
     /// Returns the `compact`ed result of applying `transform` to each of the `Right` values or re-wraps `Left`
     func flatMapEach<V>(@noescape transform: RightType.Generator.Element -> Either<LeftType, V>) -> Either<LeftType, [V]> {
-        return either(
-            ifLeft: Either<LeftType, [V]>.left,
-            ifRight: { $0.flatMap(transform).compact() })
+        return flatMap { $0.flatMap(transform).compact() }
     }
 
     /// Maps each `Right` value with `transform`, or re-wraps `Left`.

--- a/Kaleidoscope/EitherExtensions.swift
+++ b/Kaleidoscope/EitherExtensions.swift
@@ -5,6 +5,7 @@
 
 import Either
 import Prelude
+import Darwin
 
 // These are in Either’s upstream, but not released yet and Madness is bringing in Either, so…
 extension Either {
@@ -18,6 +19,21 @@ extension Either {
         return either(
             ifLeft: transform,
             ifRight: Either<V, U>.right)
+    }
+}
+
+extension Either {
+    /// Prints the left or right to `leftStream` or `rightStream` respectively
+    /// and terminates the program with exit code 1 for left or 0 for right.
+    @noreturn func materialize<OutTarget: OutputStreamType, ErrorTarget: OutputStreamType>(inout leftStream leftStream: OutTarget, inout rightStream: ErrorTarget) {
+        switch self {
+        case let .Left(left):
+            print(left, toStream: &leftStream)
+            exit(1)
+        case let .Right(right):
+            print(right, toStream: &rightStream)
+            exit(0)
+        }
     }
 }
 

--- a/Kaleidoscope/LibraryCodegen.swift
+++ b/Kaleidoscope/LibraryCodegen.swift
@@ -1,0 +1,62 @@
+//
+//  LibraryCodegen.swift
+//  Kaleidoscope
+//
+//  Created by Ben Cochran on 11/20/15.
+//  Copyright © 2015 Ben Cochran. All rights reserved.
+//
+
+import LLVM
+import Either
+import Prelude
+
+// MARK: `putchard`
+
+private func declarePutchar(context: CodegenContext) -> Either<Error,Function> {
+    let intType = IntType.int32(inContext: context.context)
+    let type = FunctionType(returnType: intType, paramTypes: [intType], isVarArg: false)
+    let function = Function(name: "putchar", type: type, inModule: context.module)
+    if function.name != "putchar" {
+        return .left(.codegenError("Error generating prototype `putchar`: actually generated `\(function.name ?? "(null)")`"))
+    }
+    return .right(function)
+}
+
+/// In C, this would be:
+///
+///   double putchard(double c) {
+///     return (double)putchar((int) c);
+///   }
+func generatePutchard(context: CodegenContext) -> Either<Error, Function> {
+    return declarePutchar(context).flatMap { putchar in
+        // Create `putchard` declaration
+        let doubleType = RealType.double(inContext: context.context)
+        let type = FunctionType(returnType: doubleType, paramTypes: [doubleType], isVarArg: false)
+        let function = Function(name: "putchard", type: type, inModule: context.module)
+        if function.name != "putchard" {
+            return .left(.codegenError("Error generating prototype `putchard`: actually generated `\(function.name ?? "(null)")`"))
+        }
+        
+        // Create a new basic block to start insertion into.
+        let block = function.appendBasicBlock("entry", context: context.context)
+        
+        // Position the builder at the end of the block
+        context.builder.positionAtEnd(block: block)
+        
+        let input = function.paramAtIndex(0)
+
+        // Cast the input to an int
+        let intType = IntType.int32(inContext: context.context)
+        let castedInput = context.builder.buildFPToUI(input, destinationType: intType, name: "tmpinput")
+        
+        // Build the call to `putchar`
+        let result = context.builder.buildCall(putchar, args: [castedInput], name: "tmpcall")
+        
+        // Cast the result to a double and build the return
+        let castedResult = context.builder.buildUIToFP(result, destinationType: doubleType, name: "tmpreturn")
+        context.builder.buildReturn(value: castedResult)
+        
+        // Verify the function along the way
+        return context.verifyFunction(function) >>- const(.right(function))
+    }
+}

--- a/Kaleidoscope/LibraryCodegen.swift
+++ b/Kaleidoscope/LibraryCodegen.swift
@@ -60,3 +60,62 @@ func generatePutchard(context: CodegenContext) -> Either<Error, Function> {
         return context.verifyFunction(function) >>- const(.right(function))
     }
 }
+
+// MARK: `printd`
+
+private func declarePrintf(context: CodegenContext) -> Either<Error,Function> {
+    let int32Type = IntType.int32(inContext: context.context)
+    let int8Type = IntType.int8(inContext: context.context)
+    let pointerType = PointerType(type: int8Type, addressSpace: 0) // TODO: address space ?
+    let type = FunctionType(returnType: int32Type, paramTypes: [pointerType], isVarArg: true)
+    let function = Function(name: "printf", type: type, inModule: context.module)
+    if function.name != "printf" {
+        return .left(.codegenError("Error generating prototype `printf`: actually generated `\(function.name ?? "(null)")`"))
+    }
+    return .right(function)
+}
+
+/// In C, this would be:
+///
+///   double printd(double d) {
+///     return (double)printf("%f", d);
+///   }
+func generatePrintd(context: CodegenContext) -> Either<Error, Function> {
+    return declarePrintf(context).flatMap { printf in
+        // Create format string constant: "%f"
+        let formatConstant = context.builder.buildGlobalString("%f", name: "format")
+        
+        // Create printd declaration
+        let doubleType = RealType.double(inContext: context.context)
+        let type = FunctionType(returnType: doubleType, paramTypes: [doubleType], isVarArg: false)
+        let function = Function(name: "printd", type: type, inModule: context.module)
+        if function.name != "printd" {
+            return .left(.codegenError("Error generating prototype `printd`: actually generated `\(function.name ?? "(null)")`"))
+        }
+
+        // Create a new basic block to start insertion into.
+        let block = function.appendBasicBlock("entry", context: context.context)
+        
+        // Position the builder at the end of the block
+        context.builder.positionAtEnd(block: block)
+        
+        let input = function.paramAtIndex(0)
+        
+        // Build an array of [0, 0] as constants
+        let int32Type = IntType.int32(inContext: context.context)
+        let indices: [ValueType] = [IntConstant.type(int32Type, value: 0, shouldSignExtend: false), IntConstant.type(int32Type, value: 0, shouldSignExtend: false)]
+        
+        // Get pointer to the format constant
+        let format = context.builder.buildInBoundsGEP(formatConstant, indices: indices, name: "tmpptr")
+        
+        // Call `printf`
+        let result = context.builder.buildCall(printf, args: [format, input], name: "tmpcalll")
+        
+        // Cast the result to a double and build the return
+        let castedResult = context.builder.buildUIToFP(result, destinationType: doubleType, name: "tmpreturn")
+        context.builder.buildReturn(value: castedResult)
+        
+        // Verify the function along the way
+        return context.verifyFunction(function) >>- const(.right(function))
+    }
+}

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -14,7 +14,14 @@ import Prelude
 func compileModule(lines: [String]) -> Either<Error, CodegenContext> {
     let context = CodegenContext(moduleName: "kaleidoscope", context: Context.globalContext)
 
-    return compile(lines, inContext: context) >>- const(.right(context))
+    return Either.right(lines) &&& generateStandardLibrary(context)
+        >>- compile
+        >>- const(.right(context))
+}
+
+private func generateStandardLibrary(context: CodegenContext) -> Either<Error, CodegenContext> {
+    return generatePutchard(context)
+        >>- const(.right(context))
 }
 
 private func compile(lines: [String], inContext context: CodegenContext) -> Either<Error, [ValueType]> {
@@ -59,8 +66,9 @@ var stderr = OutputStream.Err
 
 
 let lines = [
+    "extern putchard(x);",
     "extern addThree(a b c);",
-    "def main() addThree(1 2 3);",
+    "def main() putchard(addThree(1 2 39));",
     "def add(a b) a + b;",
     "def addThree(x y z) add(add(x y) z);"
 ]

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -69,8 +69,9 @@ var stderr = OutputStream.Err
 let lines = [
     "extern putchard(x);",
     "extern printd(x);",
+    "def printlnd(d) printd(d) + putchard(10);", // Kind of a hack using addition here, but just go with it
     "extern addThree(a b c);",
-    "def main() printd(addThree(1 2 -10.5));",
+    "def main() printlnd(addThree(1 2 -10.5));",
     "def add(a b) a + b;",
     "def addThree(x y z) add(add(x y) z);"
 ]

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -11,10 +11,52 @@ import LLVM
 import Either
 import Prelude
 
+func compileModule(lines: [String]) -> Either<Error, CodegenContext> {
+    let context = CodegenContext(moduleName: "kaleidoscope", context: Context.globalContext)
+
+    return compile(lines, inContext: context) >>- const(.right(context))
+}
+
+private func compile(lines: [String], inContext context: CodegenContext) -> Either<Error, [ValueType]> {
+    return parseLines(lines) >>- Analyzer.analyze >>- codegen(context)
+}
+
+private func parseLines(lines: [String]) -> Either<Error, [Expression]> {
+    return lines
+        .map {
+            // Parse each expression
+            return parseTopLevelExpression($0)
+                // Wrap errors
+                .mapLeft(Error.parseError)
+                // Cast as Expression
+                .map(id)
+                // Lift `main` to a MainExpression
+                .flatMap(liftMain)
+        }
+        // Compact the array of `Either`s into a single `Either` of `Array`
+        .compact()
+}
+
+private func codegen(context: CodegenContext)(expressions: [Expression]) -> Either<Error, [ValueType]> {
+    return expressions
+        // Attempt to cast each Expression to Codegenable
+        .map(attemptCast)
+        // Compact the array of `Either`s into a single `Either` of `Array`
+        .compact()
+        // Perform code generation in the context
+        .flatMapEach(codegenInContext(context))
+}
+
+func extractModule(context: CodegenContext) -> Either<Error, String> {
+    guard let ir = context.module.string else {
+        return .left(Error(kind: .CodegenError, message: "Unable to generate IR"))
+    }
+    return .right(ir)
+}
+
 var stdout = OutputStream.Out
 var stderr = OutputStream.Err
 
-let context = CodegenContext(moduleName: "kaleidoscope", context: Context.globalContext)
 
 let lines = [
     "extern addThree(a b c);",
@@ -23,34 +65,7 @@ let lines = [
     "def addThree(x y z) add(add(x y) z);"
 ]
 
-let result = lines
-    .map {
-        // Parse each expression
-        return parseTopLevelExpression($0)
-            // Wrap errors
-            .mapLeft(Error.parseError)
-            // Cast as Expression
-            .map(id)
-            // Lift `main` to a MainExpression
-            .flatMap(liftMain)
-    }
-    // Compact the array of `Either`s into a single `Either` of `Array`
-    .compact()
-    // Analize the expressions
-    .flatMap(Analyzer.analyze)
-    // Attempt to cast each Expression to Codegenable
-    .flatMapEach(attemptCast)
-    // Perform code generation in the context
-    .flatMapEach(codegenInContext(context))
-
-if case let .Left(error) = result {
-    print("Failed: \(error)", toStream: &stderr)
-    exit(1)
-}
-
-guard let ir = context.module.string else {
-    print("Failed to generate IR", toStream: &stderr)
-    exit(1)
-}
-
-print(ir, toStream: &stdout)
+compileModule(lines)
+    .flatMap(extractModule)
+    .mapLeft { String("Failed: \($0)") }
+    .materialize(leftStream: &stderr, rightStream: &stdout)

--- a/Kaleidoscope/main.swift
+++ b/Kaleidoscope/main.swift
@@ -21,6 +21,7 @@ func compileModule(lines: [String]) -> Either<Error, CodegenContext> {
 
 private func generateStandardLibrary(context: CodegenContext) -> Either<Error, CodegenContext> {
     return generatePutchard(context)
+        &&& generatePrintd(context)
         >>- const(.right(context))
 }
 
@@ -67,8 +68,9 @@ var stderr = OutputStream.Err
 
 let lines = [
     "extern putchard(x);",
+    "extern printd(x);",
     "extern addThree(a b c);",
-    "def main() putchard(addThree(1 2 39));",
+    "def main() printd(addThree(1 2 -10.5));",
     "def add(a b) a + b;",
     "def addThree(x y z) add(add(x y) z);"
 ]


### PR DESCRIPTION
Does a little by-hand codeine to express things that can’t natively be expressed in Kaleidoscope or by KaleidoscopeLang’s `Expression` (namely: typecasts, string literals) (see #12).

In C, the added methods would be:

``` C
double putchard(double c) {
    return (double)putchar((int) c);
}

double printd(double d) {
    return (double)printf("%f", d);
}
```

This enables us to write programs that actually produce visible output. 😍

(This also cleans up main.swift a bit)

Closes #5
